### PR TITLE
Fix OKX websocket login and add timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY pyproject.toml .
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev
+    && poetry install --no-dev --no-interaction --no-ansi
 COPY . .
 CMD ["doge-runner"]

--- a/src/monitors.py
+++ b/src/monitors.py
@@ -26,7 +26,7 @@ class Monitors:
 
     # ----- Funding via WebSocket -----
     async def funding_loop(self, perp: PerpExec, borrow: BorrowMgr):
-        async for msg in self.gw.ws_private_stream("funding-rate"):
+        async for msg in self.gw.ws_private_stream("funding-rate", self.pair_swap):
             d = msg["data"][0]
             if d["instId"] != self.pair_swap:
                 continue
@@ -59,7 +59,7 @@ class Monitors:
     # ----- Liquidation guard -----
     async def liq_loop(self, perp: PerpExec, borrow: BorrowMgr):
         """Emergency close if mark price approaches liquidation price."""
-        async for msg in self.gw.ws_private_stream("positions"):
+        async for msg in self.gw.ws_private_stream("positions", self.pair_swap):
             p = msg["data"][0]
             if p["instId"] != self.pair_swap or p.get("posSide") != "short":
                 continue


### PR DESCRIPTION
## Summary
- add WS login procedure before subscribing to private streams
- support instId filtering and reconnect with timeout
- adjust funding and liq monitors to pass instrument id
- quiet Dockerfile install

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_686ad7d5bae0832fa64f4211d584b0e7