### PR TITLE
Borrow USDT before buying spot

### DIFF
--- a/src/executors/spot.py
+++ b/src/executors/spot.py
@@ -11,19 +11,18 @@ class SpotExec:
     def __init__(self, gw: OKXGateway, db: StateDB, inst: str):
         self.gw, self.db, self.inst = gw, db, inst
 
-    async def buy(self, qty: Decimal):
+    async def buy(self, qty: Decimal, loan_auto: bool = True):
         px = "0"  # market
-        res = await self.gw.post(
-            "/api/v5/trade/order",
-            {
-                "instId": self.inst,
-                "side": "buy",
-                "ordType": "market",
-                "sz": str(qty),
-                "tdMode": "cash",
-                "loanTrans": "auto",
-            },
-        )
+        params = {
+            "instId": self.inst,
+            "side": "buy",
+            "ordType": "market",
+            "sz": str(qty),
+            "tdMode": "cash",
+        }
+        if loan_auto:
+            params["loanTrans"] = "auto"
+        res = await self.gw.post("/api/v5/trade/order", params)
         log.info("SPOT_BUY", resp=res)
         await tg.send(f"Spot BUY {qty} {self.inst}")
         spot, perp, loan = await self.db.get()

--- a/src/runner.py
+++ b/src/runner.py
@@ -25,10 +25,13 @@ async def init_positions(spot: SpotExec, perp: PerpExec, borrow: BorrowMgr, db: 
         return
     # fresh start
     equity = float(os.getenv("EQUITY_USDT", "1000"))
-    price = float((await spot.gw.get("/api/v5/market/ticker", {"instId": PAIR_SPOT}))[0]["last"])
-    spot_target = equity / price
-    await spot.buy(Decimal(spot_target))
-    await borrow.borrow(equity * 2)
+    price = float(
+        (await spot.gw.get("/api/v5/market/ticker", {"instId": PAIR_SPOT}))[0]["last"]
+    )
+    loan_amt = equity * 2
+    await borrow.borrow(loan_amt)
+    spot_target = (equity + loan_amt) / price
+    await spot.buy(Decimal(spot_target), loan_auto=False)
     await perp.short(Decimal(spot_target))
 
 async def main():


### PR DESCRIPTION
## Summary
- borrow USDT before purchasing spot position
- disable auto-loan for initial spot purchase
- allow SpotExec.buy() to skip auto loaning with a flag

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_686ae494e14c832fb943c5a90b871fa4