### PR TITLE
Implement WS reconnect and order rejection checks

### DIFF
--- a/src/executors/perp.py
+++ b/src/executors/perp.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import structlog
+import httpx
 from ..core.gateway import OKXGateway
 from ..db.state import StateDB
 from ..alerts.telegram import tg
@@ -11,26 +12,40 @@ class PerpExec:
         self.gw, self.db, self.inst = gw, db, inst
 
     async def short(self, qty: Decimal):
-        res = await self.gw.post(
-            "/api/v5/trade/order",
-            {
-                "instId": self.inst,
-                "side": "sell",
-                "ordType": "market",
-                "tdMode": "cross",
-                "sz": str(qty),
-            },
-        )
+        try:
+            res = await self.gw.post(
+                "/api/v5/trade/order",
+                {
+                    "instId": self.inst,
+                    "side": "sell",
+                    "ordType": "market",
+                    "tdMode": "cross",
+                    "sz": str(qty),
+                },
+            )
+        except httpx.HTTPStatusError as e:
+            await tg.send(f"❌ Perp SHORT rejected: {e.response.text[:120]}")
+            raise
+        if res[0].get("sCode") != "0":
+            await tg.send(f"❌ Perp SHORT failed: {res}")
+            raise RuntimeError("orderRejected")
         log.info("PERP_SHORT_OPEN", resp=res)
         await tg.send(f"Perp SHORT {qty}")
         spot, perp, loan = await self.db.get()
         await self.db.save(spot, perp - float(qty), loan)
 
     async def close_all(self):
-        res = await self.gw.post(
-            "/api/v5/trade/close-position",
-            {"instId": self.inst, "mgnMode": "cross", "posSide": "short"},
-        )
+        try:
+            res = await self.gw.post(
+                "/api/v5/trade/close-position",
+                {"instId": self.inst, "mgnMode": "cross", "posSide": "short"},
+            )
+        except httpx.HTTPStatusError as e:
+            await tg.send(f"❌ Perp CLOSE rejected: {e.response.text[:120]}")
+            raise
+        if res[0].get("sCode") != "0":
+            await tg.send(f"❌ Perp CLOSE failed: {res}")
+            raise RuntimeError("orderRejected")
         log.info("PERP_CLOSE", resp=res)
         await tg.send("Perp short closed")
         spot, _, loan = await self.db.get()


### PR DESCRIPTION
## Summary
- ensure OKX websocket reconnects after drops
- validate market order responses for spot & perp executions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check src/executors/spot.py src/executors/perp.py src/core/gateway.py`


------
https://chatgpt.com/codex/tasks/task_e_686ae7870614832fb3ee9b854f548f91