### PR TITLE
Implement PnL stop and warn on trading errors

### DIFF
--- a/src/core/gateway.py
+++ b/src/core/gateway.py
@@ -8,8 +8,8 @@ import os
 import base64
 import hashlib
 import hmac
-from pydantic import BaseModel
 from typing import Any, AsyncGenerator, Dict
+from ..alerts.telegram import tg
 
 log = structlog.get_logger()
 OKX_HOST = "https://www.okx.com"
@@ -49,12 +49,23 @@ class OKXGateway:
         r.raise_for_status()
         return r.json()["data"]
 
+    async def get_equity(self) -> float:
+        data = await self.get("/api/v5/account/balance", {"ccy": "USDT"})
+        return float(data[0]["totalEq"])
+
     async def post(self, path: str, payload: dict) -> Any:
         body = json.dumps(payload, separators=(",", ":"))
         hdr = await self._headers("POST", path, body)
         r = await self.rest.post(path, headers=hdr, content=body)
         r.raise_for_status()
-        return r.json()["data"]
+        resp = r.json()
+        if resp.get("code") != "0":
+            log.warning("API_ERROR", path=path, code=resp.get("code"), msg=resp.get("msg"))
+        for item in resp.get("data", []):
+            if item.get("sCode") == "51000":
+                await tg.send(f"⚠️ order rejected {item.get('sMsg')}")
+                log.warning("ORDER_REJECTED", code="51000", msg=item.get("sMsg"))
+        return resp.get("data", [])
 
     # ----------  WebSocket ----------
     async def ws(self) -> websockets.WebSocketClientProtocol:

--- a/src/db/state.py
+++ b/src/db/state.py
@@ -13,6 +13,12 @@ create table if not exists bot_state (
     loan_usdt    real not null default 0
 );
 insert or ignore into bot_state (id) values (1);
+create table if not exists equity_ref (
+    id integer primary key check (id = 1),
+    eq_usd  real not null default 0,
+    ts      integer not null default 0
+);
+insert or ignore into equity_ref (id) values (1);
 """
 
 class StateDB:
@@ -35,5 +41,18 @@ class StateDB:
             await db.execute(
                 "update bot_state set spot_qty=?, perp_qty=?, loan_usdt=? where id=1",
                 (spot, perp, loan),
+            )
+            await db.commit()
+
+    async def get_eq_ref(self) -> Tuple[float, int]:
+        async with self._lock, aiosqlite.connect(self.path) as db:
+            row = await db.execute_fetchone("select eq_usd, ts from equity_ref where id=1")
+            return row  # (equity, timestamp)
+
+    async def save_eq_ref(self, eq_usd: float, ts: int):
+        async with self._lock, aiosqlite.connect(self.path) as db:
+            await db.execute(
+                "update equity_ref set eq_usd=?, ts=? where id=1",
+                (eq_usd, ts),
             )
             await db.commit()

--- a/src/runner.py
+++ b/src/runner.py
@@ -55,6 +55,7 @@ async def main():
         mon.risk_loop(),
         mon.apr_poll(borrow, perp_exec),
         mon.liq_loop(perp_exec, borrow),
+        mon.pnl_guard(),
         reb.run(),
     ]
     await tg.send("DOGE‑carry bot Started")


### PR DESCRIPTION
## Summary
- add Telegram warning when OKX API rejects an order
- track daily equity value in DB
- monitor equity drop via `pnl_guard`
- start the new monitor in the runner

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ae7885050832f9ad8000dba733f0b