### PR TITLE
Fix WS stream stall handling

### DIFF
--- a/src/core/gateway.py
+++ b/src/core/gateway.py
@@ -144,6 +144,11 @@ class OKXGateway:
                 await self._reset_ws()
                 await self.ws_send({"op": "subscribe", "args": [sub_arg]})
                 continue
+            except Exception as e:
+                log.error("WS_STREAM_ERR", exc_info=e)
+                await self._reset_ws()
+                await self.ws_send({"op": "subscribe", "args": [sub_arg]})
+                continue
             msg = json.loads(raw)
             if msg.get("event") == "error":
                 log.error("WS_ERR", data=msg)


### PR DESCRIPTION
## Summary
- handle unexpected exceptions in `ws_private_stream`

## Testing
- `python -m compileall -q src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b71249108832fba5931e1f672c8d1