### PR TITLE
Add db volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,8 @@ services:
       - "9090:9090"
     restart: unless-stopped
     command: doge-runner
+    volumes:
+      - dbdata:/app/src/db
+
+volumes:
+  dbdata:

--- a/readme.md
+++ b/readme.md
@@ -12,3 +12,4 @@ persistent state in SQLite and WebSocket monitoring.
    docker compose up -d
    ```
 3. Prometheus metrics available on port `9090`.
+4. Persistent database files are stored in the `dbdata` Docker volume mounted at `src/db`.


### PR DESCRIPTION
## Summary
- add named volume `dbdata` in compose
- mount volume to bot service
- document persistent volume usage

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b72414d5c832f9b16b3842bf37a79